### PR TITLE
Version 0.21.2: Adopt some changes from "styles" branch

### DIFF
--- a/mapsforgesrv/src/main/java/com/telemaxx/mapsforgesrv/MapsforgeSrv.java
+++ b/mapsforgesrv/src/main/java/com/telemaxx/mapsforgesrv/MapsforgeSrv.java
@@ -57,7 +57,12 @@
  *         re-enable HTTP request property "userScale"
  *         some code optimizations
  * 0.21.1: fix "IllegalStateException" on /updatemapstyle request (nono303)
- ******************************************************************************/
+ * 0.21.2: Adopt some changes from "styles" branch:
+ *		   Handle UTF-8 characters in config file correctly
+ *		   Automatically enable built-in world map if map definition is missing or empty
+ *		   Remove request query parameters x, y and z and log invalid tile request paths
+ *		   Assign default file extension .png if file extension missing in tile request path
+ * ******************************************************************************/
 
 package com.telemaxx.mapsforgesrv;
 
@@ -78,7 +83,7 @@ import org.slf4j.bridge.SLF4JBridgeHandler;
 
 public class MapsforgeSrv {
 	
-	private final static String VERSION = "0.21.1"; // starting with eg 0.13, the mapsforge version //$NON-NLS-1$
+	private final static String VERSION = "0.21.2"; // starting with eg 0.13, the mapsforge version //$NON-NLS-1$
 	
 	final static Logger logger = LoggerFactory.getLogger(MapsforgeSrv.class);
 

--- a/mapsforgesrv/src/main/java/com/telemaxx/mapsforgesrv/MapsforgeStyleParser.java
+++ b/mapsforgesrv/src/main/java/com/telemaxx/mapsforgesrv/MapsforgeStyleParser.java
@@ -92,7 +92,7 @@ public class MapsforgeStyleParser {
 	 * @param xmlFile
 	 * @return a list with availible, visible layers
 	 */
-	@SuppressWarnings({ "null" })
+//	@SuppressWarnings({ "null" })
 	public List<Style> readXML(final String xmlFile) {
 
 		final List<Style> items = new ArrayList<>();
@@ -111,6 +111,7 @@ public class MapsforgeStyleParser {
 					final StartElement startElement = event.asStartElement();
 					// if stylemenue, getting the defaults
 					if (startElement.getName().getLocalPart().equals(STYLE_MENU)) {
+						@SuppressWarnings("unchecked")
 						final Iterator<Attribute> sm_attributes = startElement.getAttributes();
 						while (sm_attributes.hasNext()) { //in the same line as <layer>
 							final Attribute sm_attribute = sm_attributes.next();
@@ -127,6 +128,7 @@ public class MapsforgeStyleParser {
 					if (startElement.getName().getLocalPart().equals(XML_LAYER)) {
 						Style = false;
 						item = new Style();
+						@SuppressWarnings("unchecked")
 						final Iterator<Attribute> attributes = startElement.getAttributes();
 						while (attributes.hasNext()) { //in the same line as <layer>
 							final Attribute attribute = attributes.next();
@@ -142,7 +144,8 @@ public class MapsforgeStyleParser {
 					}
                if (event.isStartElement()) {
                   if (event.asStartElement().getName().getLocalPart().equals(NAME)) {
-                  	final Iterator<Attribute> name_attributes = startElement.getAttributes();
+                  	@SuppressWarnings("unchecked")
+					final Iterator<Attribute> name_attributes = startElement.getAttributes();
    						while (name_attributes.hasNext()) { //in the same line as <layer>
    							final Attribute name_attribute = name_attributes.next();
    							if (name_attribute.getName().toString().equals(LANG)){


### PR DESCRIPTION
- Handle UTF-8 characters in config file correctly
- Automatically enable built-in world map if map definition is missing or empty
- Remove request query parameters x, y and z and log invalid tile request paths
- Assign default file extension .png if file extension missing in tile request path